### PR TITLE
Entferne nicht benutzte lokale Variable in der Klasse Camera

### DIFF
--- a/engine-alpha/src/main/java/ea/Camera.java
+++ b/engine-alpha/src/main/java/ea/Camera.java
@@ -275,8 +275,6 @@ public final class Camera {
      */
     @Internal
     public Point toScreenPixelLocation(Vector locationInWorld, float pixelPerMeter) {
-        //Punktposition relativ zur aktuellen Kameraposition
-        Vector locationInWorldCameraRelative = position.getDistance(locationInWorld);
         Vector cameraRelativeLocInPx = position.multiply(pixelPerMeter);
 
         Vector frameSize = Game.getFrameSizeInPixels();


### PR DESCRIPTION
Dadurch wird der Warnhinweis im Editor entfernt. Die lokale Variable kann sicher schnell wieder hinzugefügt werden, wenn sie wirklich gebraucht wird.