### PR TITLE
Entferne nicht benutzte private Attribute

### DIFF
--- a/engine-alpha/src/main/java/ea/actor/Polygon.java
+++ b/engine-alpha/src/main/java/ea/actor/Polygon.java
@@ -24,16 +24,6 @@ public class Polygon extends Geometry {
     private int[] scaledPx, scaledPy;
 
     /**
-     * Skalierungsfaktor Breite
-     */
-    private float scaleX;
-
-    /**
-     * Skalierungsfaktor Höhe.
-     */
-    private float scaleY;
-
-    /**
      * Erstellt ein neues Polygon. Seine Position ist der <b>Ursprung</b>.
      *
      * @param points Der Streckenzug an Punkten, der das Polygon beschreibt. Alle


### PR DESCRIPTION
Dadurch werden die Warnhinweise im Editor entfernt. Außerdem können diese Attribute schnell wieder hinzugefügt werden, wenn sie wirklich gebraucht werden.