### PR TITLE
Vereinheitliche die Verwendung von Umlauten

### DIFF
--- a/engine-alpha-examples/src/main/java/ea/example/showcase/PhysicsSandbox.java
+++ b/engine-alpha-examples/src/main/java/ea/example/showcase/PhysicsSandbox.java
@@ -295,11 +295,11 @@ public class PhysicsSandbox extends ShowcaseDemo implements MouseClickListener, 
             case KeyEvent.VK_J: //Decrease Mass
                 changeMass(-10);
                 break;
-            case KeyEvent.VK_W: //Elastizitaet der Wände erhöhen
+            case KeyEvent.VK_W: //Elastizität der Wände erhöhen
                 ground.setRestitution(ground.getRestitution() + 0.1f);
                 System.out.println("Ela der Wand " + ground.getRestitution());
                 break;
-            case KeyEvent.VK_Q: //Elastizitaet der Wände erhöhen
+            case KeyEvent.VK_Q: //Elastizität der Wände erhöhen
                 ground.setRestitution(ground.getRestitution() - 0.1f);
                 System.out.println("Ela der Wand " + ground.getRestitution());
                 break;

--- a/engine-alpha/src/main/java/ea/Camera.java
+++ b/engine-alpha/src/main/java/ea/Camera.java
@@ -29,16 +29,16 @@ import java.awt.Point;
 /**
  * Die Kamera "blickt" auf die Zeichenebene, das was sie sieht beschreibt den Teil der Zeichenebene;
  * das, was im Window dargestellt wird.<br> Sie kann ein Objekt fokussieren und ihm so folgen.
- * Hierbei besteht auch die Moeglichkeit, diesen Fokus in Grenzen zu halten. Und zwar durch die
- * Fokus-Bounds. Diese 4 Grenzwerte koennen individuell verstellt und aktiviert werden. auch kann
+ * Hierbei besteht auch die Möglichkeit, diesen Fokus in Grenzen zu halten. Und zwar durch die
+ * Fokus-Bounds. Diese 4 Grenzwerte können individuell verstellt und aktiviert werden. auch kann
  * man den von der Kamera darzustellenden Bereich durch eine einzige Methode definieren, in dem man
  * den Bereich als Bounds beschreibt.<br> <br> <br> <br> <code> Bounds
  * grenzen = new Bounds(0, 0, 1500, 1000);<br> meineCam.setBounds(grenzen);<br>
  * </code> <br> <br> <br> Hierdurch wird automatisch der gesamte Fokusapparat (auf den Bereich
- * zwischen den Punkten (0|0) und (1500|1000) ) eingestellt. Bei spezielleren Fokuswuenschen laesst
+ * zwischen den Punkten (0|0) und (1500|1000) ) eingestellt. Bei spezielleren Fokuswuenschen lässt
  * sich dies ebenfalls arrangieren durch die einzelnen Methoden, mit denen alle vier Bounds (N, S,
- * O, W) einzeln verstellt und (de)aktiviert werden koennen.<br> <b>!!Achtung!!</b><br> Bei den
- * Fokuseinstellungen sollte immer ein Bereich gewaehlt werden, der die Groesse des Anzeigefensters
+ * O, W) einzeln verstellt und (de)aktiviert werden können.<br> <b>!!Achtung!!</b><br> Bei den
+ * Fokuseinstellungen sollte immer ein Bereich gewählt werden, der die Grösse des Anzeigefensters
  * (oder Vollbildes) bei weitem uebersteigt.<br> Allgemein wirken diese Bounds auch ohne
  * aktivierten Fokus. jedoch ist dies meist weniger sinnvoll.
  *

--- a/engine-alpha/src/main/java/ea/Camera.java
+++ b/engine-alpha/src/main/java/ea/Camera.java
@@ -38,7 +38,7 @@ import java.awt.Point;
  * zwischen den Punkten (0|0) und (1500|1000) ) eingestellt. Bei spezielleren Fokuswuenschen lässt
  * sich dies ebenfalls arrangieren durch die einzelnen Methoden, mit denen alle vier Bounds (N, S,
  * O, W) einzeln verstellt und (de)aktiviert werden können.<br> <b>!!Achtung!!</b><br> Bei den
- * Fokuseinstellungen sollte immer ein Bereich gewählt werden, der die Grösse des Anzeigefensters
+ * Fokuseinstellungen sollte immer ein Bereich gewählt werden, der die Größe des Anzeigefensters
  * (oder Vollbildes) bei weitem uebersteigt.<br> Allgemein wirken diese Bounds auch ohne
  * aktivierten Fokus. jedoch ist dies meist weniger sinnvoll.
  *

--- a/engine-alpha/src/main/java/ea/internal/Bounds.java
+++ b/engine-alpha/src/main/java/ea/internal/Bounds.java
@@ -170,7 +170,7 @@ public final class Bounds {
      *
      * @param upperBound Die Grenze, auf der das Ergebnis maximal liegen darf.
      *
-     * @return Ein Bounds derselben Hoehe und Breite wie dieses, das in jedem Fall below,
+     * @return Ein Bounds derselben Höhe und Breite wie dieses, das in jedem Fall below,
      * oder auf der Grenze liegt, wenn es passt, ist es <code>this</code>.
      */
     public Bounds below(float upperBound) {
@@ -376,9 +376,9 @@ public final class Bounds {
     }
 
     /**
-     * Gibt die <b>reelle</b> Hoehe aus.
+     * Gibt die <b>reelle</b> Höhe aus.
      *
-     * @return Die <b>reelle</b> Hoehe dieses BoundingRechtecks.
+     * @return Die <b>reelle</b> Höhe dieses BoundingRechtecks.
      *
      * @see #getX()
      * @see #getY()

--- a/engine-alpha/src/main/java/ea/internal/physics/PhysicsHandler.java
+++ b/engine-alpha/src/main/java/ea/internal/physics/PhysicsHandler.java
@@ -132,7 +132,7 @@ public interface PhysicsHandler {
     float getMass();
 
     /**
-     * Uebt eine Kraft auf das Ziel-Objekt (im Massenschwerpunkt) aus (sofern möglich).
+     * Übt eine Kraft auf das Ziel-Objekt (im Massenschwerpunkt) aus (sofern möglich).
      *
      * @param force Die Kraft, die auf den Massenschwerpunkt angewandt werden soll. <b>Nicht in [px]</b>, sondern in
      *              [N] = [m / s^2].


### PR DESCRIPTION
Meistens sind die Umlaute in der Dokumentation als einzelne Unicode-Zeichen hinterlegt, an manchen Stellen jedoch durch zwei ASCII-Zeichen dargestellt. 