### PR TITLE
Unify the use of the annotations @API and @Internal in the interpolator classes.

### DIFF
--- a/engine-alpha/src/main/java/ea/animation/interpolation/ConstantInterpolator.java
+++ b/engine-alpha/src/main/java/ea/animation/interpolation/ConstantInterpolator.java
@@ -2,6 +2,7 @@ package ea.animation.interpolation;
 
 import ea.animation.Interpolator;
 import ea.internal.annotations.API;
+import ea.internal.annotations.Internal;
 
 /**
  * Ein Interpolator, der eine konstante Funktion darstellt.
@@ -22,6 +23,7 @@ public class ConstantInterpolator<Value> implements Interpolator<Value> {
         this.value = value;
     }
 
+    @Internal
     @Override
     public Value interpolate(float progress) {
         return value;

--- a/engine-alpha/src/main/java/ea/animation/interpolation/CosinusFloat.java
+++ b/engine-alpha/src/main/java/ea/animation/interpolation/CosinusFloat.java
@@ -1,6 +1,8 @@
 package ea.animation.interpolation;
 
 import ea.animation.Interpolator;
+import ea.internal.annotations.API;
+import ea.internal.annotations.Internal;
 
 /**
  * Interpoliert auf einer kompletten Cosinuskurve.
@@ -32,11 +34,13 @@ implements Interpolator<Float> {
      *                      <li>Nach 4/4 der Zeit <code>start</code></li>
      *                  </ul>
      */
+    @API
     public CosinusFloat(float start, float amplitude) {
         this.start = start;
         this.amplitude = amplitude;
     }
 
+    @Internal
     @Override
     public Float interpolate(float progress) {
         return (float)Math.cos(Math.PI * progress * 2)*amplitude + start - amplitude;

--- a/engine-alpha/src/main/java/ea/animation/interpolation/LinearFloat.java
+++ b/engine-alpha/src/main/java/ea/animation/interpolation/LinearFloat.java
@@ -20,16 +20,20 @@
 package ea.animation.interpolation;
 
 import ea.animation.Interpolator;
+import ea.internal.annotations.API;
+import ea.internal.annotations.Internal;
 
 public class LinearFloat implements Interpolator<Float> {
     private float start;
     private float end;
 
+    @API
     public LinearFloat(float start, float end) {
         this.start = start;
         this.end = end;
     }
 
+    @Internal
     @Override
     public Float interpolate(float progress) {
         return this.start + (this.end - this.start) * progress;

--- a/engine-alpha/src/main/java/ea/animation/interpolation/LinearInteger.java
+++ b/engine-alpha/src/main/java/ea/animation/interpolation/LinearInteger.java
@@ -20,16 +20,20 @@
 package ea.animation.interpolation;
 
 import ea.animation.Interpolator;
+import ea.internal.annotations.API;
+import ea.internal.annotations.Internal;
 
 public class LinearInteger implements Interpolator<Integer> {
     private int start;
     private int end;
 
+    @API
     public LinearInteger(int start, int end) {
         this.start = start;
         this.end = end;
     }
 
+    @Internal
     @Override
     public Integer interpolate(float progress) {
         return this.start + (int) ((this.end - this.start) * progress);

--- a/engine-alpha/src/main/java/ea/animation/interpolation/ReverseEaseFloat.java
+++ b/engine-alpha/src/main/java/ea/animation/interpolation/ReverseEaseFloat.java
@@ -20,16 +20,20 @@
 package ea.animation.interpolation;
 
 import ea.animation.Interpolator;
+import ea.internal.annotations.API;
+import ea.internal.annotations.Internal;
 
 public class ReverseEaseFloat implements Interpolator<Float> {
     private float startAndEnd;
     private float middle;
 
+    @API
     public ReverseEaseFloat(float startAndEnd, float middle) {
         this.startAndEnd = startAndEnd;
         this.middle = middle;
     }
 
+    @Internal
     @Override
     public Float interpolate(float progress) {
         return this.startAndEnd + (float) Math.sin(progress * Math.PI) * (this.middle - this.startAndEnd);

--- a/engine-alpha/src/main/java/ea/animation/interpolation/SinusFloat.java
+++ b/engine-alpha/src/main/java/ea/animation/interpolation/SinusFloat.java
@@ -1,6 +1,8 @@
 package ea.animation.interpolation;
 
 import ea.animation.Interpolator;
+import ea.internal.annotations.API;
+import ea.internal.annotations.Internal;
 
 /**
  * Interpoliert auf einer kompletten Sinuskurve.
@@ -27,11 +29,13 @@ public class SinusFloat implements Interpolator<Float> {
      *                  <code>start+amplitude</code> und bei 3/4 ist der Wert <code>start-amplitude</code>.<br>
      *                  Negative Werte sind natürlich auch möglich.
      */
+    @API
     public SinusFloat(float start, float amplitude) {
         this.start = start;
         this.amplitude = amplitude;
     }
 
+    @Internal
     @Override
     public Float interpolate(float progress) {
         return (float)Math.sin(Math.PI * progress * 2)*amplitude + start;


### PR DESCRIPTION
The class `EaseInOutFloat` was used as a model. In this class the construtor has an `@API` and the interpolate method an `@Internal` annotation.