### PR TITLE
Close the scanner to avoid a resource leak

### DIFF
--- a/engine-alpha/src/main/java/ea/internal/FixtureBuilder.java
+++ b/engine-alpha/src/main/java/ea/internal/FixtureBuilder.java
@@ -116,6 +116,7 @@ public final class FixtureBuilder {
             Shape shape = fromLine(line);
             shapeList.add(new FixtureData(shape));
         }
+        scanner.close();
         return () -> shapeList;
     }
 


### PR DESCRIPTION
This change will eliminate the warning:

    Resource leak: 'scanner' is never closed Java(536871799)