### PR TITLE
Add missing copyright and license header

### DIFF
--- a/engine-alpha/src/main/java/ea/FrameUpdateListener.java
+++ b/engine-alpha/src/main/java/ea/FrameUpdateListener.java
@@ -1,3 +1,22 @@
+/*
+ * Engine Alpha ist eine anfängerorientierte 2D-Gaming Engine.
+ *
+ * Copyright (c) 2011 - 2023 Michael Andonie and contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ea;
 
 import ea.internal.annotations.API;

--- a/engine-alpha/src/main/java/ea/Layer.java
+++ b/engine-alpha/src/main/java/ea/Layer.java
@@ -1,3 +1,22 @@
+/*
+ * Engine Alpha ist eine anfängerorientierte 2D-Gaming Engine.
+ *
+ * Copyright (c) 2011 - 2023 Michael Andonie and contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ea;
 
 import ea.actor.Actor;

--- a/engine-alpha/src/main/java/ea/Random.java
+++ b/engine-alpha/src/main/java/ea/Random.java
@@ -1,3 +1,22 @@
+/*
+ * Engine Alpha ist eine anfängerorientierte 2D-Gaming Engine.
+ *
+ * Copyright (c) 2011 - 2023 Michael Andonie and contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ea;
 
 import ea.internal.annotations.API;

--- a/engine-alpha/src/main/java/ea/actor/Polygon.java
+++ b/engine-alpha/src/main/java/ea/actor/Polygon.java
@@ -1,3 +1,22 @@
+/*
+ * Engine Alpha ist eine anfängerorientierte 2D-Gaming Engine.
+ *
+ * Copyright (c) 2011 - 2023 Michael Andonie and contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ea.actor;
 
 import ea.Vector;

--- a/engine-alpha/src/main/java/ea/actor/StatefulAnimation.java
+++ b/engine-alpha/src/main/java/ea/actor/StatefulAnimation.java
@@ -1,3 +1,22 @@
+/*
+ * Engine Alpha ist eine anfängerorientierte 2D-Gaming Engine.
+ *
+ * Copyright (c) 2011 - 2023 Michael Andonie and contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ea.actor;
 
 import ea.internal.FixtureBuilder;

--- a/engine-alpha/src/main/java/ea/actor/TileContainer.java
+++ b/engine-alpha/src/main/java/ea/actor/TileContainer.java
@@ -1,3 +1,22 @@
+/*
+ * Engine Alpha ist eine anfängerorientierte 2D-Gaming Engine.
+ *
+ * Copyright (c) 2011 - 2023 Michael Andonie and contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ea.actor;
 
 import ea.internal.FixtureBuilder;

--- a/engine-alpha/src/main/java/ea/animation/CircleAnimation.java
+++ b/engine-alpha/src/main/java/ea/animation/CircleAnimation.java
@@ -1,3 +1,22 @@
+/*
+ * Engine Alpha ist eine anfängerorientierte 2D-Gaming Engine.
+ *
+ * Copyright (c) 2011 - 2023 Michael Andonie and contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ea.animation;
 
 import ea.Vector;

--- a/engine-alpha/src/main/java/ea/animation/KeyFrame.java
+++ b/engine-alpha/src/main/java/ea/animation/KeyFrame.java
@@ -1,3 +1,22 @@
+/*
+ * Engine Alpha ist eine anfängerorientierte 2D-Gaming Engine.
+ *
+ * Copyright (c) 2011 - 2023 Michael Andonie and contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ea.animation;
 
 import ea.animation.interpolation.EaseInOutFloat;

--- a/engine-alpha/src/main/java/ea/animation/KeyFrames.java
+++ b/engine-alpha/src/main/java/ea/animation/KeyFrames.java
@@ -1,3 +1,22 @@
+/*
+ * Engine Alpha ist eine anfängerorientierte 2D-Gaming Engine.
+ *
+ * Copyright (c) 2011 - 2023 Michael Andonie and contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ea.animation;
 
 import ea.FrameUpdateListener;

--- a/engine-alpha/src/main/java/ea/animation/LineAnimation.java
+++ b/engine-alpha/src/main/java/ea/animation/LineAnimation.java
@@ -1,3 +1,22 @@
+/*
+ * Engine Alpha ist eine anfängerorientierte 2D-Gaming Engine.
+ *
+ * Copyright (c) 2011 - 2023 Michael Andonie and contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ea.animation;
 
 import ea.Vector;

--- a/engine-alpha/src/main/java/ea/animation/interpolation/ConstantInterpolator.java
+++ b/engine-alpha/src/main/java/ea/animation/interpolation/ConstantInterpolator.java
@@ -1,3 +1,22 @@
+/*
+ * Engine Alpha ist eine anfängerorientierte 2D-Gaming Engine.
+ *
+ * Copyright (c) 2011 - 2023 Michael Andonie and contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ea.animation.interpolation;
 
 import ea.animation.Interpolator;

--- a/engine-alpha/src/main/java/ea/animation/interpolation/CosinusFloat.java
+++ b/engine-alpha/src/main/java/ea/animation/interpolation/CosinusFloat.java
@@ -1,3 +1,22 @@
+/*
+ * Engine Alpha ist eine anfängerorientierte 2D-Gaming Engine.
+ *
+ * Copyright (c) 2011 - 2023 Michael Andonie and contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ea.animation.interpolation;
 
 import ea.animation.Interpolator;

--- a/engine-alpha/src/main/java/ea/animation/interpolation/EaseInOutFloat.java
+++ b/engine-alpha/src/main/java/ea/animation/interpolation/EaseInOutFloat.java
@@ -1,3 +1,22 @@
+/*
+ * Engine Alpha ist eine anfängerorientierte 2D-Gaming Engine.
+ *
+ * Copyright (c) 2011 - 2023 Michael Andonie and contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ea.animation.interpolation;
 
 import ea.animation.Interpolator;

--- a/engine-alpha/src/main/java/ea/animation/interpolation/SinusFloat.java
+++ b/engine-alpha/src/main/java/ea/animation/interpolation/SinusFloat.java
@@ -1,3 +1,22 @@
+/*
+ * Engine Alpha ist eine anfängerorientierte 2D-Gaming Engine.
+ *
+ * Copyright (c) 2011 - 2023 Michael Andonie and contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ea.animation.interpolation;
 
 import ea.animation.Interpolator;

--- a/engine-alpha/src/main/java/ea/collision/CollisionEvent.java
+++ b/engine-alpha/src/main/java/ea/collision/CollisionEvent.java
@@ -1,3 +1,22 @@
+/*
+ * Engine Alpha ist eine anfängerorientierte 2D-Gaming Engine.
+ *
+ * Copyright (c) 2011 - 2023 Michael Andonie and contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ea.collision;
 
 import ea.Vector;

--- a/engine-alpha/src/main/java/ea/internal/graphics/AnimationFrame.java
+++ b/engine-alpha/src/main/java/ea/internal/graphics/AnimationFrame.java
@@ -1,3 +1,22 @@
+/*
+ * Engine Alpha ist eine anfängerorientierte 2D-Gaming Engine.
+ *
+ * Copyright (c) 2011 - 2023 Michael Andonie and contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ea.internal.graphics;
 
 //import com.sun.corba.se.impl.orbutil.graph.Graph;

--- a/engine-alpha/src/main/java/ea/internal/io/ImageWriter.java
+++ b/engine-alpha/src/main/java/ea/internal/io/ImageWriter.java
@@ -1,3 +1,22 @@
+/*
+ * Engine Alpha ist eine anfängerorientierte 2D-Gaming Engine.
+ *
+ * Copyright (c) 2011 - 2023 Michael Andonie and contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ea.internal.io;
 
 import ea.internal.util.Logger;

--- a/engine-alpha/src/main/java/ea/internal/physics/BodyHandler.java
+++ b/engine-alpha/src/main/java/ea/internal/physics/BodyHandler.java
@@ -1,3 +1,22 @@
+/*
+ * Engine Alpha ist eine anfängerorientierte 2D-Gaming Engine.
+ *
+ * Copyright (c) 2011 - 2023 Michael Andonie and contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ea.internal.physics;
 
 import ea.Vector;

--- a/engine-alpha/src/main/java/ea/internal/physics/FixtureData.java
+++ b/engine-alpha/src/main/java/ea/internal/physics/FixtureData.java
@@ -1,3 +1,22 @@
+/*
+ * Engine Alpha ist eine anfängerorientierte 2D-Gaming Engine.
+ *
+ * Copyright (c) 2011 - 2023 Michael Andonie and contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ea.internal.physics;
 
 import ea.internal.annotations.Internal;

--- a/engine-alpha/src/main/java/ea/internal/physics/NullHandler.java
+++ b/engine-alpha/src/main/java/ea/internal/physics/NullHandler.java
@@ -1,3 +1,22 @@
+/*
+ * Engine Alpha ist eine anfängerorientierte 2D-Gaming Engine.
+ *
+ * Copyright (c) 2011 - 2023 Michael Andonie and contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ea.internal.physics;
 
 import ea.Vector;

--- a/engine-alpha/src/main/java/ea/internal/physics/PhysicsData.java
+++ b/engine-alpha/src/main/java/ea/internal/physics/PhysicsData.java
@@ -1,4 +1,23 @@
-package ea.internal.physics;
+/*
+ * Engine Alpha ist eine anfängerorientierte 2D-Gaming Engine.
+ *
+ * Copyright (c) 2011 - 2023 Michael Andonie and contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ package ea.internal.physics;
 
 import ea.Vector;
 import ea.actor.Actor;

--- a/engine-alpha/src/main/java/ea/internal/physics/PhysicsHandler.java
+++ b/engine-alpha/src/main/java/ea/internal/physics/PhysicsHandler.java
@@ -1,3 +1,22 @@
+/*
+ * Engine Alpha ist eine anfängerorientierte 2D-Gaming Engine.
+ *
+ * Copyright (c) 2011 - 2023 Michael Andonie and contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ea.internal.physics;
 
 import ea.Vector;

--- a/engine-alpha/src/main/java/ea/internal/physics/WorldHandler.java
+++ b/engine-alpha/src/main/java/ea/internal/physics/WorldHandler.java
@@ -1,3 +1,22 @@
+/*
+ * Engine Alpha ist eine anfängerorientierte 2D-Gaming Engine.
+ *
+ * Copyright (c) 2011 - 2023 Michael Andonie and contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ea.internal.physics;
 
 import ea.Layer;


### PR DESCRIPTION
Most files have a header with the copyright notice and license. For some files this header is missing completely. This change adds a header to all Java files of the engine-alpha module and thus unifies the source code.