### PR TITLE
Unify white space handling

### DIFF
--- a/engine-alpha/src/test/java/ea/LoggerTest.java
+++ b/engine-alpha/src/test/java/ea/LoggerTest.java
@@ -9,9 +9,9 @@ import java.nio.file.Paths;
 import static org.junit.Assert.assertTrue;
 
 public class LoggerTest {
-	@Test
-	public void fileExists () {
-		Logger.error("LoggerTest", "lorem ipsum");
-		assertTrue(Files.exists(Paths.get("engine-alpha.log")));
-	}
+    @Test
+    public void fileExists () {
+        Logger.error("LoggerTest", "lorem ipsum");
+        assertTrue(Files.exists(Paths.get("engine-alpha.log")));
+    }
 }

--- a/engine-alpha/src/test/java/ea/OptimizerTest.java
+++ b/engine-alpha/src/test/java/ea/OptimizerTest.java
@@ -13,27 +13,27 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assume.assumeFalse;
 
 public class OptimizerTest {
-	@Test
-	public void optimizeImage () {
-		assumeFalse(GraphicsEnvironment.isHeadless());
+    @Test
+    public void optimizeImage () {
+        assumeFalse(GraphicsEnvironment.isHeadless());
 
-		BufferedImage img = null;
+        BufferedImage img = null;
 
-		try {
-			img = ImageIO.read(EngineAlpha.class.getResource("/assets/logo.png"));
-		} catch (Exception e) {
-			Logger.error("OptimizerTest", e.getLocalizedMessage());
-		}
+        try {
+            img = ImageIO.read(EngineAlpha.class.getResource("/assets/logo.png"));
+        } catch (Exception e) {
+            Logger.error("OptimizerTest", e.getLocalizedMessage());
+        }
 
-		assertNotNull(img);
+        assertNotNull(img);
 
-		BufferedImage opt = Optimizer.toCompatibleImage(img);
-		assertNotNull(opt);
+        BufferedImage opt = Optimizer.toCompatibleImage(img);
+        assertNotNull(opt);
 
-		assertEquals(img.getWidth(), opt.getWidth());
-		assertEquals(img.getHeight(), opt.getHeight());
+        assertEquals(img.getWidth(), opt.getWidth());
+        assertEquals(img.getHeight(), opt.getHeight());
 
-		BufferedImage opt2 = Optimizer.toCompatibleImage(opt);
-		assertEquals(opt.getColorModel(), opt2.getColorModel());
-	}
+        BufferedImage opt2 = Optimizer.toCompatibleImage(opt);
+        assertEquals(opt.getColorModel(), opt2.getColorModel());
+    }
 }


### PR DESCRIPTION
Most classes are written with a 4-space indentation and do not use tabs