### PR TITLE
Capture stderr and test stderr

### DIFF
--- a/engine-alpha/src/test/java/ea/LoggerTest.java
+++ b/engine-alpha/src/test/java/ea/LoggerTest.java
@@ -1,17 +1,37 @@
 package ea;
 
-import ea.internal.util.Logger;
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-import static org.junit.Assert.assertTrue;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import ea.internal.util.Logger;
 
 public class LoggerTest {
+
+	private final PrintStream standardErr = System.err;
+	private final ByteArrayOutputStream errStreamCaptor = new ByteArrayOutputStream();
+
+	@Before
+	public void setUp() {
+		System.setErr(new PrintStream(errStreamCaptor));
+	}
+
+	@After
+	public void tearDown() {
+		System.setErr(standardErr);
+	}
+
 	@Test
-	public void fileExists () {
+	public void fileExists() {
 		Logger.error("LoggerTest", "lorem ipsum");
+		assertTrue(errStreamCaptor.toString().indexOf("lorem ipsum") > -1);
 		assertTrue(Files.exists(Paths.get("engine-alpha.log")));
 	}
 }


### PR DESCRIPTION
This commit removes the misleading error message when running the tests in the terminal using mvn test.

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running ea.VectorTest
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.039 s - in ea.VectorTest
[INFO] Running ea.LoggerTest
[Tue Nov 07 09:48:08 CET 2023][ERROR][LoggerTest] lorem ipsum (LoggerTest.java:14)
java.lang.RuntimeException
	at ea.internal.util.Logger.error(Logger.java:140)
	at ea.LoggerTest.fileExists(LoggerTest.java:14)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:577)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:364)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:272)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:237)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:158)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:428)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:562)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:548)
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s - in ea.LoggerTest
```
