### PR TITLE
Add maven-plugin-sources to pom.xml

### DIFF
--- a/engine-alpha-edu/pom.xml
+++ b/engine-alpha-edu/pom.xml
@@ -43,6 +43,19 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                          <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/engine-alpha/pom.xml
+++ b/engine-alpha/pom.xml
@@ -44,6 +44,21 @@
         <finalName>engine-alpha-4</finalName>
 
         <plugins>
+
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-source-plugin</artifactId>
+              <version>3.3.0</version>
+              <executions>
+                <execution>
+                  <id>attach-sources</id>
+                  <goals>
+                    <goal>jar</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>

--- a/engine-alpha/pom.xml
+++ b/engine-alpha/pom.xml
@@ -42,23 +42,7 @@
 
     <build>
         <finalName>engine-alpha-4</finalName>
-
         <plugins>
-
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-source-plugin</artifactId>
-              <version>3.3.0</version>
-              <executions>
-                <execution>
-                  <id>attach-sources</id>
-                  <goals>
-                    <goal>jar</goal>
-                  </goals>
-                </execution>
-              </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
@@ -74,6 +58,19 @@
                         <phase>package</phase>
                         <goals>
                             <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
To display the API documentation in the IDE, I need a JAR file that contains the source code. So far, I have created a separate branch in my fork for this purpose. It would be nice if the engine could generate the *-source.jar files by default.

I use this command to install the JAR files:

```sh
mvn install:install-file \
		-Dfile=engine-alpha-4-jar-with-dependencies.jar \
		-DgroupId=org.engine-alpha \
		-DartifactId=engine-alpha-parent \
		-Dsources=engine-alpha-4-sources.jar \
		-Dversion=4.0.0-SNAPSHOT \
		-Dpackaging=jar
``